### PR TITLE
Fix #38223, Make dialog center on the screen without taskbar

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,7 @@ int getScreenWidth()
         return 0;
 
     int width = scrn->width;
+    int height = scrn->height;
 
     if (NULL != disp)
         XCloseDisplay(disp);
@@ -160,6 +161,8 @@ int main(int argc, char *argv[])
         XAtomHelper::getInstance()->setWindowMotifHint(w.winId(), hints);
 
         w.show();
+        w.move ((QApplication::desktop()->availableGeometry().width() - w.width())/2,
+               (QApplication::desktop()->availableGeometry().height() - w.height())/2);
         return app.exec();
     }
     return 0;


### PR DESCRIPTION
Fix #38223, Make dialog center on the screen without taskbar